### PR TITLE
Sets the process title for the app so that it shows up in top / ps as "btlock" instead of just python

### DIFF
--- a/btlock
+++ b/btlock
@@ -6,6 +6,7 @@ import time
 import logging
 import configargparse
 import bt_proximity
+import setproctitle
 
 def parse_config():
     config_files = ['{0}/btlock/config'.format('/etc'),
@@ -98,6 +99,7 @@ def watch(config):
         time.sleep(interval)
 
 def main():
+    setproctitle.setproctitle("btlock")
     config = parse_config()
     setup_logging(config.verbose)
     watch(config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ConfigArgParse>=0.13,<1
 PyBluez>=0.22,<1
 bt-proximity>=0.1,<1
+setproctitle>=1.1.10


### PR DESCRIPTION
Sets the process title, so that it shows up as btlock in top / ps -e / activity monitor as btlock instead of the not very useful default 'python'
